### PR TITLE
Update __init__.py to reflect docs

### DIFF
--- a/pyradigm/__init__.py
+++ b/pyradigm/__init__.py
@@ -1,7 +1,7 @@
 
 from sys import version_info
 
-if version_info.major==2 and version_info.minor==7 and version_info.micro==13:
+if version_info.major==2 and version_info.minor==7:
     from pyradigm import MLDataset
 elif version_info.major > 2:
     from pyradigm.pyradigm import MLDataset


### PR DESCRIPTION
Docs:

> Supported versions: 2.7, 3.5 and 3.6

This PR allows the code to reflect this statement. This PR allows any Python 2.7 version, not exactly 2.7.13 (but leaves Python 3.0-3.4 to be run at own risk).