### PR TITLE
more checks for inconsistent feature names

### DIFF
--- a/pyradigm/base.py
+++ b/pyradigm/base.py
@@ -300,6 +300,11 @@ class BaseDataset(ABC):
         if features.size <= 0:
             raise EmptyFeatureSetException('Provided features are empty.')
 
+        if self._num_features and self._num_features != features.size:
+            raise ValueError('dimensionality of supplied features ({}) '
+                                'does not match existing samplets ({})'
+                                ''.format(features.size, self._num_features))
+
         if not self._allow_nan_inf:
             if np.isnan(features).any() or np.isinf(features).any():
                 raise InfiniteOrNaNValuesException('NaN or Inf values found!'
@@ -1047,10 +1052,6 @@ class BaseDataset(ABC):
 
         if item in self._data:
             features = self._check_features(features)
-            if self._num_features != features.size:
-                raise ValueError('dimensionality of supplied features ({}) '
-                                 'does not match existing samplets ({})'
-                                 ''.format(features.size, self._num_features))
             self._data[item] = features
         else:
             raise KeyError('{} not found in dataset.'


### PR DESCRIPTION
I may have totally misunderstood the structure of `add_samplet`. 
It looks like `_data` was modified before `feature_names` was checked which lead to #45 . I pulled the checks out and into `_check_feature_names` and also pushed a ValueError for feature dim mismatch into `_check_features` (to fix the tests I broke). 

I think the same mismatch issue might exist for `attrs`. But I didn't want to work on that yet -- in case I totally missed the point.

I added two tests that check for a new exception type `InvalidFeatureNamesException.` But reviewing it now, those should maybe be `ValueError` to be consistent with the other add_samplet errors (?)

As part of the tests, I created a decorator `forall_dataset_types` to avoid putting a for loop around each test. I'm not sure if that will make debugging the tests harder. (They made writing them marginally easier)


Happy to revise if I'm not way off base. But feel free to cherry pick if any of it could be useful too.