### PR TITLE
Removing state pollution in `ds`

### DIFF
--- a/pyradigm/tests/test_BaseDataset_common_behaviours.py
+++ b/pyradigm/tests/test_BaseDataset_common_behaviours.py
@@ -253,6 +253,7 @@ def test_sanity_checks():
 
     with raises(ConstantValuesException):
         const_ds.save(out_file)
+    ds.del_samplet('all_constant')
 
 
 def forall_dataset_types(func):


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_sanity_checks` by removing state pollution in `ds` by calling method `del_samplet`

The test can fail in this way if state pollution in `ds` is not removed:
```
>       ds.add_samplet('all_constant', const_feat_set, 'target')
...
        if samplet_id in self._data and not overwrite:
>           raise ValueError('{} already exists in this dataset!'.format(samplet_id))
E           ValueError: all_constant already exists in this dataset!

pyradigm/base.py:442: ValueError
